### PR TITLE
Add initial Kubernetes deployment (example)

### DIFF
--- a/k8s/deploy.sh
+++ b/k8s/deploy.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+minikube start
+
+minikube enable addons ingress
+
+kubectl cluster-info
+
+kubectl apply -f deployment.yml
+
+kubectl get pods -o wide
+kubectl get services -o wide
+kubectl get ingress -o wide

--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: remla-deployment
+  labels:
+    app: remla
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: remla-app
+  template:
+    metadata:
+      labels:
+        app: remla-app
+    spec:
+      containers:
+      - name: remla-app
+        image: crpaulsen/remla-app
+        command: ["tail"]
+        args: ["-f", "/dev/null"]
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service
+spec:
+  selector:
+    app: remla-app
+  ports:
+      # By default and for convenience, the `targetPort` is set to the same value as the `port` field.
+    - port: 80
+      targetPort: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: my-ingress
+spec:
+  defaultBackend:
+    service:
+      name: my-service
+      port:
+        number: 80
+


### PR DESCRIPTION
The kubernetes deployment needs to be adjusted further, but this
requires the app to have some kind of endpoint as the app currently
does not do anything while running.