### PR TITLE
ci: add if-statement to avoid checking commits on merges

### DIFF
--- a/.github/workflows/check-commit-format.yml
+++ b/.github/workflows/check-commit-format.yml
@@ -4,6 +4,8 @@ on: [push]
 
 jobs:
   build:
+    # Do not run commit check on merge commits
+    if: github.event.pull_request.merged == 'false'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
The new Github Action that checks the commit format does not work well with merge commits. None of the cz "commit options" really fit with that of a merge commit, and rebasing (to avoid creating a merge commit) breaks the action.

There are of course many ways we could go about this but I thought I would try 1) modify the action so that it does not run on merge commits using `github.event.pull_request.merged == 'false'`, 2) if that doesn't work -- disable commit check for the master branch (as master is protected anyway, so all commits made to master should be merge commits).

This will take some messing around with PRs to test whether it's working.