### PR TITLE
Add endpoint for browser interaction

### DIFF
--- a/dvc.lock
+++ b/dvc.lock
@@ -46,6 +46,9 @@ stages:
     - path: data/derivates/cleaned_train_dataset_properties.pkl
       md5: 29c600e89cf8129ebc8b7a75dbad48f4
       size: 114384
+    - path: data/derivates/tfidf_vectorizer.pkl
+      md5: 4676f254668c64a79ef5fecd161d1a2c
+      size: 5381481
     - path: data/derivates/tfidf_vocab.pkl
       md5: 4539842f91487ff205c66a58442b5913
       size: 304689

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -15,6 +15,7 @@ stages:
     - data/processed/validation.pkl
     - data/derivates/cleaned_train_dataset_properties.pkl
     - data/derivates/tfidf_vocab.pkl
+    - data/derivates/tfidf_vectorizer.pkl
   data_validation:
     cmd: pytest tests/test_data_validation.py
     deps:

--- a/src/models/serve_model.py
+++ b/src/models/serve_model.py
@@ -4,7 +4,7 @@ Flask API of the SMS Spam detection model model.
 
 import pickle
 import random
-from flask import Flask, jsonify, request, Response
+from flask import Flask, jsonify, request, Response, render_template
 from flasgger import Swagger
 
 from src.config.definitions import ROOT_DIR
@@ -15,8 +15,52 @@ swagger = Swagger(app)
 
 NUM_PRED = 0
 
+@app.route('/', methods=['GET'])
+def index_get():
+    """
+    Show a landing page to the user.
+    """
+    return render_template('index.html')
+
+@app.route('/', methods=['POST'])
+def index_post():
+    """
+    Show the predicted tags from user input.
+    """
+    title = request.form['text']
+
+    if not title:
+        return render_template('index.html')
+
+    predicted_tags  = predict(title)
+    data = [f"Title: {title}", f"Tags: {predicted_tags}"]
+
+    return render_template('index.html', data=data)
+
+
+def predict(title):
+    """
+    Function that returns the predicted tags of the given title.
+    Used in the endpoints.
+    """
+    prepared_title = text_prepare(title) # remove bad symbols
+    processed_title = tfidf_vectorizer.transform([prepared_title])
+
+    with open(ROOT_DIR / 'models/tfidf.pkl', 'rb') as file:
+        model = pickle.load(file)
+    prediction = model.predict(processed_title)[0]
+    # global statement is used to keep track of predictions, this is the simplest solution
+    # pylint: disable=global-statement
+    global NUM_PRED
+    NUM_PRED = NUM_PRED + 1  # Increment number of total predictions made
+
+    # TODO: Convert preediction: binary array -> list of tags as strings ?
+
+    return prediction
+
+
 @app.route('/predict', methods=['POST'])
-def predict():
+def predict_post():
     """
     Predict the tag belonging to the title of a post of StackOverflow.
     ---
@@ -43,18 +87,7 @@ def predict():
     input_data = request.get_json()
     title = input_data.get('title')
 
-    prepared_title = text_prepare(title) # remove bad symbols
-    processed_title = tfidf_vectorizer.transform([prepared_title])
-
-    with open(ROOT_DIR / 'models/tfidf.pkl', 'rb') as file:
-        model = pickle.load(file)
-    prediction = model.predict(processed_title)[0]
-    # global statement is used to keep track of predictions, this is the simplest solution
-    # pylint: disable=global-statement
-    global NUM_PRED
-    NUM_PRED = NUM_PRED + 1  # Increment number of total predictions made
-
-    # TODO: Convert preediction: binary array -> list of tags as strings ?
+    prediction = predict(title)
 
     return jsonify({
         "result": prediction.tolist(),

--- a/src/models/templates/index.html
+++ b/src/models/templates/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>REMLA app by Group 13</title>
+</head>
+<body>
+    <h1>REMLA app by Group 13</h1>
+    <form method="POST">
+	    <input name="text" placeholder="Enter a title">
+	    <input type="submit" value="Predict tags">
+    </form>
+    {% for text in data %}
+    	<p>{{text}}</p>
+    {% endfor %}
+</body>
+</html>
+


### PR DESCRIPTION
This PR adds an endpoint for "/" with some simple HTML.
This allows for some more visual browser interaction and in-browser debugging.

Landing page (`localhost:8080/`):
<img width="385" alt="image" src="https://user-images.githubusercontent.com/18667772/172215484-9146f02a-aef0-427c-9efe-ab74d428b853.png">

Displaying prediction on landing page:
<img width="376" alt="image" src="https://user-images.githubusercontent.com/18667772/172224658-499e73ad-80d2-4cd3-9ba5-21c9dcb0bc80.png">

### How to test?
Option 1: no docker
1. (OPTIONAL) Run `pip install -r requirements.txt` and `pip install -e .[all]` if you haven't done so in your local environment lately.
2. Run `python src/models/serve-model.py`
3. Access `localhost:8080/` in your browser

Option 2: docker
1. Run `docker build . -t <tag_name>`
2. Run `docker run --rm -p 8080:8080 <tag_name>`
3. Access `localhost:8080/` in your browser