### PR TITLE
Automate and document Grafana setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ Users can then provide feedback on the quality of the predicted tags.
 
 The application is based on the jupyter notebook provided by [luiscruz/remla-baseline-project](https://github.com/luiscruz/remla-baseline-project).
 
-
 ## Setup guide
 The REMLA-app can be deployed in two ways: singular deployment or blue-green deployment.
 #### Deployments requirements:
@@ -38,6 +37,8 @@ Deploys a singular deployment.
 This script will set up a Minikube cluster and deploy only the blue version of REMLA-app.
 The image version used by blue is kept up-to-date in this repository with the latest released image version.
 
+**Note**: When running the script for the first time, you will be prompted to set a password for the Grafana dashboard.
+
 ### `deploy-bg.sh <color> <version>`: 
 Deploys the given color deployment with the given version.
 The script will wait until the deployment is successful, then switch traffic to the newly deployed version.
@@ -66,6 +67,14 @@ You will need the following:
 * The `k8s/` directory. Modify the manifests to point to your own application images.
 * Implement your own Prometheus alert(s). Modify `k8s/alert_rules.yml` and `k8s/values.yml` to match your desired alert(s) configuration.
 
+## Grafana dashboard
+The Grafana dashboard is accessible on `<ingress_ip>/dashboard`.
+
+We provide a custom dashboard that displays our application-specific metrics (`user_satisfaction`, `num_pred`) which is stored in `k8s/grafana-dashboards/metrics_dashboard.json`.
+
+Log in to the Grafana dashboard with username `admin` and the password you set when running `deploy-simple.sh` for the first time.
+
+To import the dashboard go to Create -> Import and copy-paste the json in `k8s/grafana-dashboards/metrics_dashboard.json`.
 
 ## Contributing
 To prepare your local environment for development, install all requirements using `pip install -r requirements.txt`. 

--- a/deploy-simple.sh
+++ b/deploy-simple.sh
@@ -15,6 +15,15 @@ minikube addons enable ingress
 kubectl cluster-info
 # Run "minikube dashboard" for an in-browser dashboard
 
+# Set Grafana password if running script for the first time
+if [ ! -f k8s/values.yml ]; then
+    echo "INFO: k8s/values.yml does not exist. This is normal if it's your first time running this script, you need to provide a Grafana password first:"
+    read -sp 'Enter Grafana password: ' GRAF_PASS
+    cp k8s/values.yml.dist k8s/values.yml
+	sed -i.bak "s?<PLACEHOLDER>?$GRAF_PASS?g" k8s/values.yml
+    rm k8s/values.yml.bak
+    echo "Grafana password has been set."
+fi
 
 # Install kube-prometheus-stack used for monitoring
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts

--- a/k8s/.gitignore
+++ b/k8s/.gitignore
@@ -1,0 +1,1 @@
+values.yml

--- a/k8s/grafana-dashboards/metrics_dashboard.json
+++ b/k8s/grafana-dashboards/metrics_dashboard.json
@@ -121,7 +121,7 @@
         "x": 0,
         "y": 0
       },
-      "id": 4,
+      "id": 2,
       "options": {
         "legend": {
           "calcs": [],
@@ -139,11 +139,11 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "rate(num_pred[$__rate_interval])",
-          "refId": "A"
+          "expr": "user_satisfaction",
+          "refId": "User satisfaction rate"
         }
       ],
-      "title": "Number of requests",
+      "title": "User satisfaction",
       "type": "timeseries"
     },
     {
@@ -202,12 +202,12 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 9,
+        "h": 8,
         "w": 12,
-        "x": 0,
-        "y": 8
+        "x": 12,
+        "y": 0
       },
-      "id": 2,
+      "id": 4,
       "options": {
         "legend": {
           "calcs": [],
@@ -225,14 +225,110 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "my_random",
+          "expr": "rate(num_pred[30s])",
           "refId": "A"
         }
       ],
-      "title": "Random Value",
+      "title": "Predictions rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 6,
+        "y": 8
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "user_satisfaction",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(num_pred[30s])",
+          "hide": false,
+          "refId": "B"
+        }
+      ],
+      "title": "User satisfaction VS prediction rate",
       "type": "timeseries"
     }
   ],
+  "refresh": false,
   "schemaVersion": 36,
   "style": "dark",
   "tags": [],
@@ -240,13 +336,13 @@
     "list": []
   },
   "time": {
-    "from": "now-1h",
+    "from": "now-15m",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
-  "title": "My metrics",
-  "uid": "kCIJrLrnz",
-  "version": 1,
+  "title": "Metrics dashboard",
+  "uid": "8FHzPR3nk",
+  "version": 6,
   "weekStart": ""
 }

--- a/k8s/values.yml.dist
+++ b/k8s/values.yml.dist
@@ -3,7 +3,7 @@ grafana:
     server:
       root_url: http://localhost:3000/dashboard
       serve_from_sub_path: true
-
+  adminPassword: <PLACEHOLDER>
 
 alertmanager:
   config:
@@ -24,4 +24,3 @@ alertmanager:
       webhook_configs:
         # Alert will be forwarded to the endpoint below
       - url: "http://host.minikube.internal:8081/webhook"
-


### PR DESCRIPTION
## Changes:
* Updated the grafana dashboard .json to include user satisfaction. Added a Grafana guide that explains how to access and import it. 
* Automated setting of the Grafana password when deploying (deploy-simple) for the first time

## Problems:
I was initially going to 1) automate the importing of the dashboard json so we didn't have to do this manually on start-up, 2) use some kind of k8s configmap/secrets approach to manage the Grafana admin password.

Both of these plans turned out to be way more complicated than I thought.
Mostly because we aren’t using “pure” Grafana, but an implementation through a helm chart so there is only so much I can do without cloning their repo -- which isn't possible given the time we have left. 

I therefore opted to instead 1) add a Grafana setup guide in the README, and 2) create an automated .dist solution through the deploy-simple.sh bash script for setting the Grafana password on first run.

# .dist explanation
Grafana is set up using some additional settings that may be configured in `k8s/values.yml`. 
This is where you would set the admin password. To avoid committing this to git, I've replaced `k8s/values.yml` with `k8s/values.yml.dist` which contains `<PLACEHOLDER>` instead of the password, and put `k8s/values.yml` under gitignore.

This means that whoever wants to deploy our project must first rename `k8s/values.yml.dist` to `k8s/values.yml` and replace `<PLACEHOLDER>` with a password of their choice.

This is a bit tedious, so I automated this in the deploy script that sets up Grafana (`deploy-simple.sh`).
The script will prompt you for a password if it's run for the first time, and create the file for you with your password.