### PR TITLE
build(cz): use cz output for container version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ jobs:
     if: "!startsWith(github.event.head_commit.message, 'bump:')"
     runs-on: ubuntu-latest
     name: "Bump version and create changelog with commitizen"
+    outputs:
+      version: ${{ steps.cz.outputs.version }}
 
     steps:
       - name: Check out
@@ -30,13 +32,10 @@ jobs:
 
   publish-docker-image:
     runs-on: ubuntu-latest
+    needs: bump_version
+
     steps:
     - uses: actions/checkout@v3
-
-    - name: Extract tag name
-      run: |
-        TAG_NAME=${GITHUB_REF:11}
-        echo "tag_name=$TAG_NAME" >> $GITHUB_ENV
     
     - name: Log in to Github Container Registery
       run: |
@@ -52,6 +51,6 @@ jobs:
         IMAGE=ghcr.io/cathrinepaulsen/remla-group13
         docker build \
           -t $IMAGE:latest \
-          -t $IMAGE:${{ env.tag_name }} \
+          -t $IMAGE:${{ needs.bump_version.outputs.version }} \
           .
         docker push --all-tags $IMAGE


### PR DESCRIPTION
The publish-docker-image job no longer runs on tag push, but instead on
every push to main. As a consequence, `GITHUB_REF` no longer refers to
the latest tag. Additionally, the action runs checkout for the commit
that triggered the action, not the commit pushed by the `bump_version`
job. Luckily GitHub actions supports job outputs, and the commitizen
action gives the new version as such an output. Use that version as the
version of the image to be pushed.