### PR TITLE
build: add dvc repro to (hopefully) fix ModuleNotFoundError originati…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,9 +48,10 @@ jobs:
       run: |
         pip install "$(grep dvc requirements.txt)"
         dvc pull
+        dvc repro
         IMAGE=ghcr.io/cathrinepaulsen/remla-group13
         docker build \
           -t $IMAGE:latest \
-          -t $IMAGE:${{ needs.bump_version.outputs.version }} \
+          -t $IMAGE:v${{ needs.bump_version.outputs.version }} \
           .
         docker push --all-tags $IMAGE


### PR DESCRIPTION
All images pushed by our Github Action have this problem:
<img width="713" alt="image" src="https://user-images.githubusercontent.com/18667772/174871259-f67fe5fc-c962-433b-9823-091ec8149176.png">

I've had this issue locally before as well which was fixed by running dvc repro if I remember correctly, so hopefully this will do.