### PR TITLE
Broken image fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,6 @@ jobs:
       run: |
         pip install "$(grep dvc requirements.txt)"
         dvc pull
-        dvc repro
         IMAGE=ghcr.io/cathrinepaulsen/remla-group13
         docker build \
           -t $IMAGE:latest \

--- a/dvc.lock
+++ b/dvc.lock
@@ -47,26 +47,26 @@ stages:
       md5: 29c600e89cf8129ebc8b7a75dbad48f4
       size: 114384
     - path: data/derivates/tfidf_vectorizer.pkl
-      md5: 4676f254668c64a79ef5fecd161d1a2c
-      size: 5381481
+      md5: 83beea4dba5a95cda408bbc3625ccf59
+      size: 5381478
     - path: data/derivates/tfidf_vocab.pkl
-      md5: 67fa2d4355b02c7fb5a4959fb0023191
-      size: 944747
+      md5: 4539842f91487ff205c66a58442b5913
+      size: 304689
     - path: data/processed/test.pkl
-      md5: 01b60bf00679071e48f7b464aa6806b3
-      size: 1652812
+      md5: b0a79cca2675fe19fec0a1764102c1d9
+      size: 1652795
     - path: data/processed/train.pkl
-      md5: 4eeb9276d03bfa527dde6dad7260f008
-      size: 12255703
+      md5: 12637bc042c74154cc176d3d859478e7
+      size: 10530934
     - path: data/processed/validation.pkl
-      md5: 601a1309a4bbce06de7e6e50f87d3b26
-      size: 3622479
+      md5: 1734eac77597b34ad2568063b62174bd
+      size: 3103689
   train_model:
     cmd: python -m src.models.train_model
     deps:
     - path: data/processed/train.pkl
-      md5: 4eeb9276d03bfa527dde6dad7260f008
-      size: 12255703
+      md5: 12637bc042c74154cc176d3d859478e7
+      size: 10530934
     - path: src/config/definitions.py
       md5: 5744b597d0c60b1b49653dc10d643c28
       size: 142
@@ -75,11 +75,11 @@ stages:
       size: 1498
     outs:
     - path: models/mlb.pkl
-      md5: 0c2048b24c371900e0cc7185e05a996b
-      size: 2311
+      md5: 7eb3a94349cd226ac41a7c769be5b3ea
+      size: 1880
     - path: models/tfidf.pkl
-      md5: 85c5d91035dee968c41b1aa42ce373f2
-      size: 14675265
+      md5: cbacd03ce8b85fb81beae773908ac85a
+      size: 14666653
   data_validation:
     cmd: pytest tests/test_data_validation.py
     deps:


### PR DESCRIPTION
I was able to recreate the "ModuleNotFound" error from the model pickle file in a local environment. "dvc repro" doesn't solve it since all stages will be skipped, but "dvc repro --force" does. I'm guessing because some of our files under dvc are out of date. I've updated the lock file and pushed the updated dvc files, so that a "dvc pull" should be sufficient in the workflow.

This should hopefully fix it. 